### PR TITLE
Add websocket server and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ If all cards are exhausted before a third monkey is eliminated, the game ends in
 ### Starting the Game
 
 Open `index.html` in a modern browser and choose a mode from the menu. You can play solo against bots or with up to three human players on the same device.
+
+## Multiplayer Server
+
+A simple Node.js server provides lobby management for online play. To run it locally:
+
+1. Install dependencies with `npm install`.
+2. Start the server with `npm start` (listens on port 3000 by default).
+3. Clients connect via WebSocket to `ws://localhost:3000`.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "moogoo-monkey-server",
+  "version": "1.0.0",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.13.0"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,107 @@
+const express = require('express');
+const http = require('http');
+const WebSocket = require('ws');
+
+const PORT = process.env.PORT || 3000;
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+// In-memory lobby storage
+const lobbies = new Map();
+
+function generateCode() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  let code = '';
+  for (let i = 0; i < 5; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  // ensure uniqueness
+  if (lobbies.has(code)) return generateCode();
+  return code;
+}
+
+function broadcast(lobby, msg, exclude) {
+  lobby.players.forEach((p) => {
+    if (p !== exclude && p.readyState === WebSocket.OPEN) {
+      p.send(JSON.stringify(msg));
+    }
+  });
+}
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data) => {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch (e) {
+      ws.send(JSON.stringify({ type: 'error', message: 'Invalid JSON' }));
+      return;
+    }
+
+    switch (msg.type) {
+      case 'createLobby':
+        {
+          const code = generateCode();
+          const lobby = {
+            code,
+            host: ws,
+            players: new Set([ws]),
+            state: {},
+          };
+          lobbies.set(code, lobby);
+          ws.lobby = lobby;
+          ws.name = msg.name || 'Host';
+          ws.send(JSON.stringify({ type: 'lobbyCreated', code }));
+        }
+        break;
+      case 'joinLobby':
+        {
+          const lobby = lobbies.get(msg.code);
+          if (!lobby) {
+            ws.send(JSON.stringify({ type: 'error', message: 'Lobby not found' }));
+            break;
+          }
+          lobby.players.add(ws);
+          ws.lobby = lobby;
+          ws.name = msg.name || 'Player';
+          ws.send(JSON.stringify({ type: 'joinedLobby', code: lobby.code, state: lobby.state }));
+          broadcast(lobby, { type: 'playerJoined', name: ws.name }, ws);
+        }
+        break;
+      case 'updateState':
+        {
+          const lobby = ws.lobby;
+          if (!lobby) {
+            ws.send(JSON.stringify({ type: 'error', message: 'Not in a lobby' }));
+            break;
+          }
+          lobby.state = msg.state;
+          broadcast(lobby, { type: 'stateUpdate', state: lobby.state });
+        }
+        break;
+      default:
+        ws.send(JSON.stringify({ type: 'error', message: 'Unknown message type' }));
+    }
+  });
+
+  ws.on('close', () => {
+    const lobby = ws.lobby;
+    if (!lobby) return;
+
+    lobby.players.delete(ws);
+    if (ws === lobby.host) {
+      // Close lobby if host disconnects
+      broadcast(lobby, { type: 'lobbyClosed' }, ws);
+      lobby.players.forEach((p) => p.close());
+      lobbies.delete(lobby.code);
+    } else {
+      broadcast(lobby, { type: 'playerLeft', name: ws.name }, ws);
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement lobby-based websocket server in `server/index.js`
- add `package.json` with express and ws dependencies
- document server startup steps in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684631343d848327bf8750e7d11634bb